### PR TITLE
Update links to the repo

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -10,6 +10,6 @@ labextension_name: jupyterlab-js-logs
 project_short_description: JupyterLab extension to show the js logs from the browser
     dev tools console
 python_name: jupyterlab_js_logs
-repository: https://github.com/QuantStack/jupyterlab-js-logs.git
+repository: https://github.com/jupyterlab-contrib/jupyterlab-js-logs.git
 test: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,25 @@
 
 ## 0.2.6
 
-([Full Changelog](https://github.com/QuantStack/jupyterlab-js-logs/compare/v0.2.5...854af201b8186f50ce781096fc46ccec758adce0))
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/compare/v0.2.5...854af201b8186f50ce781096fc46ccec758adce0))
 
 ### Enhancements made
 
-- Improve Check Release workflow [#23](https://github.com/QuantStack/jupyterlab-js-logs/pull/23) ([@hbcarlos](https://github.com/hbcarlos))
+- Improve Check Release workflow [#23](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/pull/23) ([@hbcarlos](https://github.com/hbcarlos))
 
 ### Bugs fixed
 
-- Remove prepare script and revert PR #20 [#24](https://github.com/QuantStack/jupyterlab-js-logs/pull/24) ([@hbcarlos](https://github.com/hbcarlos))
+- Remove prepare script and revert PR #20 [#24](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/pull/24) ([@hbcarlos](https://github.com/hbcarlos))
 
 ### Maintenance and upkeep improvements
 
-- Upload artifacts only on Check Release [#25](https://github.com/QuantStack/jupyterlab-js-logs/pull/25) ([@hbcarlos](https://github.com/hbcarlos))
-- Remove prepare script and revert PR #20 [#24](https://github.com/QuantStack/jupyterlab-js-logs/pull/24) ([@hbcarlos](https://github.com/hbcarlos))
-- Improve Check Release workflow [#23](https://github.com/QuantStack/jupyterlab-js-logs/pull/23) ([@hbcarlos](https://github.com/hbcarlos))
+- Upload artifacts only on Check Release [#25](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/pull/25) ([@hbcarlos](https://github.com/hbcarlos))
+- Remove prepare script and revert PR #20 [#24](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/pull/24) ([@hbcarlos](https://github.com/hbcarlos))
+- Improve Check Release workflow [#23](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/pull/23) ([@hbcarlos](https://github.com/hbcarlos))
 
 ### Contributors to this release
 
-([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-js-logs/graphs/contributors?from=2022-01-21&to=2022-01-25&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/graphs/contributors?from=2022-01-21&to=2022-01-25&type=c))
 
 [@hbcarlos](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-js-logs+involves%3Ahbcarlos+updated%3A2022-01-21..2022-01-25&type=Issues) | [@jtpio](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-js-logs+involves%3Ajtpio+updated%3A2022-01-21..2022-01-25&type=Issues)
 
@@ -30,52 +30,52 @@
 
 ## 0.2.5
 
-([Full Changelog](https://github.com/QuantStack/jupyterlab-js-logs/compare/v0.2.4...2b893318a9ee85a3c649fcb92f1ded9ba732a00d))
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/compare/v0.2.4...2b893318a9ee85a3c649fcb92f1ded9ba732a00d))
 
 ### Merged PRs
 
-- Build js in prod mode for the release [#20](https://github.com/QuantStack/jupyterlab-js-logs/pull/20) ([@hbcarlos](https://github.com/hbcarlos))
+- Build js in prod mode for the release [#20](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/pull/20) ([@hbcarlos](https://github.com/hbcarlos))
 
 ### Contributors to this release
 
-([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-js-logs/graphs/contributors?from=2021-09-15&to=2022-01-21&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/graphs/contributors?from=2021-09-15&to=2022-01-21&type=c))
 
 [@hbcarlos](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-js-logs+involves%3Ahbcarlos+updated%3A2021-09-15..2022-01-21&type=Issues)
 
 ## 0.2.4
 
-([Full Changelog](https://github.com/QuantStack/jupyterlab-js-logs/compare/v0.2.3...62cef996ed0c8434147907aa3a8bdb7bf6ffc9a6))
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/compare/v0.2.3...62cef996ed0c8434147907aa3a8bdb7bf6ffc9a6))
 
 ### Maintenance and upkeep improvements
 
-- Set name as jupyterlab-js-logs [#17](https://github.com/QuantStack/jupyterlab-js-logs/pull/17) ([@jtpio](https://github.com/jtpio))
+- Set name as jupyterlab-js-logs [#17](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/pull/17) ([@jtpio](https://github.com/jtpio))
 
 ### Documentation improvements
 
-- Update Binder link to point to the `main` branch [#16](https://github.com/QuantStack/jupyterlab-js-logs/pull/16) ([@jtpio](https://github.com/jtpio))
+- Update Binder link to point to the `main` branch [#16](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/pull/16) ([@jtpio](https://github.com/jtpio))
 
 ### Contributors to this release
 
-([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-js-logs/graphs/contributors?from=2021-09-14&to=2021-09-15&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/graphs/contributors?from=2021-09-14&to=2021-09-15&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-js-logs+involves%3Ajtpio+updated%3A2021-09-14..2021-09-15&type=Issues)
 
 ## 0.2.3
 
-([Full Changelog](https://github.com/QuantStack/jupyterlab-js-logs/compare/0.2.2...14e59dc4e5d15a3a6246d8bb1967e18fddac9b10))
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/compare/0.2.2...14e59dc4e5d15a3a6246d8bb1967e18fddac9b10))
 
 ### Bugs fixed
 
-- Remove circular references when stringifying an object [#11](https://github.com/QuantStack/jupyterlab-js-logs/pull/11) ([@hbcarlos](https://github.com/hbcarlos))
+- Remove circular references when stringifying an object [#11](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/pull/11) ([@hbcarlos](https://github.com/hbcarlos))
 
 ### Maintenance and upkeep improvements
 
-- Add `publishConfig` to `package.json` [#13](https://github.com/QuantStack/jupyterlab-js-logs/pull/13) ([@jtpio](https://github.com/jtpio))
-- Add github action to check release [#12](https://github.com/QuantStack/jupyterlab-js-logs/pull/12) ([@hbcarlos](https://github.com/hbcarlos))
+- Add `publishConfig` to `package.json` [#13](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/pull/13) ([@jtpio](https://github.com/jtpio))
+- Add github action to check release [#12](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/pull/12) ([@hbcarlos](https://github.com/hbcarlos))
 
 ### Contributors to this release
 
-([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-js-logs/graphs/contributors?from=2021-08-06&to=2021-09-14&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/graphs/contributors?from=2021-08-06&to=2021-09-14&type=c))
 
 [@hbcarlos](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-js-logs+involves%3Ahbcarlos+updated%3A2021-08-06..2021-09-14&type=Issues) | [@jtpio](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-js-logs+involves%3Ajtpio+updated%3A2021-08-06..2021-09-14&type=Issues)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jupyterlab-js-logs
 
-![Github Actions Status](https://github.com/QuantStack/jupyterlab-js-logs/workflows/Build/badge.svg)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantStack/jupyterlab-js-logs/main?urlpath=lab)
+![Github Actions Status](https://github.com/jupyterlab-contrib/jupyterlab-js-logs/workflows/Build/badge.svg)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab-contrib/jupyterlab-js-logs/main?urlpath=lab)
 
 JupyterLab extension to show the console logs from the browser dev tools console.
 

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
         "jupyterlab",
         "jupyterlab-extension"
     ],
-    "homepage": "https://github.com/QuantStack/jupyterlab-js-logs",
+    "homepage": "https://github.com/jupyterlab-contrib/jupyterlab-js-logs",
     "bugs": {
-        "url": "https://github.com/QuantStack/jupyterlab-js-logs/issues"
+        "url": "https://github.com/jupyterlab-contrib/jupyterlab-js-logs/issues"
     },
     "license": "BSD-3-Clause",
     "author": {
-        "name": "jupyterlab-js-logs contributors",
+        "name": "JupyterLab Contrib Team",
         "email": ""
     },
     "files": [
@@ -27,7 +27,7 @@
     "styleModule": "style/index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/QuantStack/jupyterlab-js-logs.git"
+        "url": "https://github.com/jupyterlab-contrib/jupyterlab-js-logs.git"
     },
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlab-contrib/jupyterlab-js-logs/issues/29